### PR TITLE
changed condition for confirmation email

### DIFF
--- a/src/app.service.ts
+++ b/src/app.service.ts
@@ -241,7 +241,7 @@ export class AppService {
           { confirmedAttendance1: payload.isConfirmed.toString() }
         );
 
-        if (payload.isConfirmed) {
+        if (currentInfoEmail == 'confirmAttendance') {
           this.emailService.sendEmail({
             template: currentInfoEmail,
             recipent: email,


### PR DESCRIPTION
changed condition for the confirmation email from payload.isConfirmed to currentEmail == 'confirmAttendance' to avoid it sending the verification email twice.